### PR TITLE
Fix pull_media local dir

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -119,7 +119,7 @@ def _pull_media():
     if env['host'] == PRODUCTION_HOST_2:
         # No need to pull media twice
         return
-    non_env_remote_media_path = _fetch_remote_variable(REMOTE_MEDIA_DIR)
+    non_env_remote_media_path = os.path.join(_fetch_remote_variable(REMOTE_MEDIA_DIR), '*')
     local('rm -rf media.old')
     local('cp -r {} {}.old || true'.format(LOCAL_MEDIA_DIR, LOCAL_MEDIA_DIR))
 


### PR DESCRIPTION
The task was recently changed to use ``$CFG_MEDIA_DIR``, which doesn't contain the ``/*`` on the end of the path meaning that rather than syncing the contents of the folder, it now syncs the folder itself so media files end up in ``/vagrant/media/media`` instead of ``/vagrant/media``

This pull request appends '*' to the media dir again fixing the issue